### PR TITLE
chore: fix permissions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pulumi-remotion-lambda",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "src/index.ts",
   "workspaces": [
     "remotion-example",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { hostedLayers } from "./hosted-layers";
 import fs from "fs";
 import { execSync } from "child_process";
 import path from "path";
+export { permissions } from "./permissions";
 
 type RemotionLambdaConfig = {
   path: string;
@@ -134,7 +135,7 @@ export class RemotionLambda extends pulumi.ComponentResource {
     this.bucket = new aws.s3.Bucket(
       name + "Bucket",
       {
-        bucket: "remotionlambda-" + name.toLowerCase(),
+        bucket: "remotionlambda-2" + name.toLowerCase(),
       },
       { parent: this }
     );

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -1,0 +1,64 @@
+export const permissions = [
+  {
+    actions: [
+      "servicequotas:GetServiceQuota",
+      "servicequotas:GetAWSDefaultServiceQuota",
+      "servicequotas:RequestServiceQuotaIncrease",
+      "servicequotas:ListRequestedServiceQuotaChangeHistoryByQuota",
+    ],
+    resources: ["*"],
+  },
+  {
+    actions: ["iam:SimulatePrincipalPolicy"],
+    resources: ["*"],
+  },
+  {
+    actions: ["iam:PassRole"],
+    resources: ["arn:aws:iam::*:role/remotion-lambda-role"],
+  },
+  {
+    actions: [
+      "s3:GetObject",
+      "s3:DeleteObject",
+      "s3:PutObjectAcl",
+      "s3:PutObject",
+      "s3:CreateBucket",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:PutBucketAcl",
+      "s3:DeleteBucket",
+      "s3:PutBucketOwnershipControls",
+      "s3:PutBucketPublicAccessBlock",
+      "s3:PutLifecycleConfiguration",
+    ],
+    resources: ["arn:aws:s3:::remotionlambda-*"],
+  },
+  {
+    actions: ["s3:ListAllMyBuckets"],
+    resources: ["*"],
+  },
+  {
+    actions: ["lambda:ListFunctions", "lambda:GetFunction"],
+    resources: ["*"],
+  },
+  {
+    actions: [
+      "lambda:InvokeAsync",
+      "lambda:InvokeFunction",
+      "lambda:CreateFunction",
+      "lambda:DeleteFunction",
+      "lambda:PutFunctionEventInvokeConfig",
+      "lambda:PutRuntimeManagementConfig",
+      "lambda:TagResource",
+    ],
+    resources: ["arn:aws:lambda:*:*:function:remotion-render-*"],
+  },
+  {
+    actions: ["logs:CreateLogGroup", "logs:PutRetentionPolicy"],
+    resources: ["arn:aws:logs:*:*:log-group:/aws/lambda/remotion-render-*"],
+  },
+  {
+    actions: ["lambda:GetLayerVersion"],
+    resources: ["arn:aws:lambda:*:678892195805:layer:remotion-binaries-*", "arn:aws:lambda:*:580247275435:layer:LambdaInsightsExtension*"],
+  },
+];

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,5 +1,6 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
+import pulumi from "@pulumi/pulumi";
 import { RemotionLambda } from "./src";
 
 export default $config({
@@ -28,9 +29,81 @@ export default $config({
         REMOTION_FUNCTION_NAME: remotion.function.name,
         REMOTION_SITE_URL: remotion.siteUrl,
         REMOTION_BUCKET_NAME: remotion.bucket.bucket,
-        // Todo: don't use admin aws keys
-        REMOTION_AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID!,
-        REMOTION_AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY!,
+      },
+      transform: {
+        server: (server) => {
+          /**
+         * Combine linked permissions with remotion execution role policy
+         * 
+         * @see https://www.remotion.dev/docs/lambda/without-iam/#1-create-role-policy
+         */
+          server.permissions = pulumi.output(server.permissions).apply((
+            permissions,
+          ) => [...(permissions ?? []), {
+            actions: [
+              "servicequotas:GetServiceQuota",
+              "servicequotas:GetAWSDefaultServiceQuota",
+              "servicequotas:RequestServiceQuotaIncrease",
+              "servicequotas:ListRequestedServiceQuotaChangeHistoryByQuota",
+            ],
+            resources: ["*"],
+          }, {
+            actions: [
+              "iam:SimulatePrincipalPolicy",
+            ],
+            resources: ["*"],
+          }, {
+            actions: ["iam:PassRole"],
+            resources: ["arn:aws:iam::*:role/remotion-lambda-role"],
+          }, {
+            actions: [
+              "s3:GetObject",
+              "s3:DeleteObject",
+              "s3:PutObjectAcl",
+              "s3:PutObject",
+              "s3:CreateBucket",
+              "s3:ListBucket",
+              "s3:GetBucketLocation",
+              "s3:PutBucketAcl",
+              "s3:DeleteBucket",
+              "s3:PutBucketOwnershipControls",
+              "s3:PutBucketPublicAccessBlock",
+              "s3:PutLifecycleConfiguration",
+            ],
+            resources: ["arn:aws:s3:::remotionlambda-*"],
+          }, {
+            actions: ["s3:ListAllMyBuckets"],
+            resources: ["*"],
+          }, {
+            actions: ["lambda:ListFunctions", "lambda:GetFunction"],
+            resources: ["*"],
+          }, {
+            actions: [
+              "lambda:InvokeAsync",
+              "lambda:InvokeFunction",
+              "lambda:CreateFunction",
+              "lambda:DeleteFunction",
+              "lambda:PutFunctionEventInvokeConfig",
+              "lambda:PutRuntimeManagementConfig",
+              "lambda:TagResource",
+            ],
+            resources: ["arn:aws:lambda:*:*:function:remotion-render-*"],
+          }, {
+            actions: [
+              "logs:CreateLogGroup",
+              "logs:PutRetentionPolicy",
+            ],
+            resources: [
+              "arn:aws:logs:*:*:log-group:/aws/lambda/remotion-render-*",
+            ],
+          }, {
+            actions: ["lambda:GetLayerVersion"],
+            resources: [
+              "arn:aws:lambda:*:678892195805:layer:remotion-binaries-*",
+              "arn:aws:lambda:*:580247275435:layer:LambdaInsightsExtension*",
+            ],
+          }]);
+        },
       },
     });
   },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -1,12 +1,11 @@
 /// <reference path="./.sst/platform/config.d.ts" />
 
-import pulumi from "@pulumi/pulumi";
-import { RemotionLambda } from "./src";
+import { RemotionLambda, permissions } from "./src";
 
 export default $config({
   app: (input) => {
     return {
-      name: "pulumi-remotion-lambda",
+      name: "pulumi-remotion",
       removal: input?.stage === "production" ? "retain" : "remove",
       home: "aws",
       providers: {
@@ -25,85 +24,11 @@ export default $config({
     });
     new sst.aws.Astro("Client", {
       path: "client",
+      permissions,
       environment: {
         REMOTION_FUNCTION_NAME: remotion.function.name,
         REMOTION_SITE_URL: remotion.siteUrl,
         REMOTION_BUCKET_NAME: remotion.bucket.bucket,
-      },
-      transform: {
-        server: (server) => {
-          /**
-         * Combine linked permissions with remotion execution role policy
-         * 
-         * @see https://www.remotion.dev/docs/lambda/without-iam/#1-create-role-policy
-         */
-          server.permissions = pulumi.output(server.permissions).apply((
-            permissions,
-          ) => [...(permissions ?? []), {
-            actions: [
-              "servicequotas:GetServiceQuota",
-              "servicequotas:GetAWSDefaultServiceQuota",
-              "servicequotas:RequestServiceQuotaIncrease",
-              "servicequotas:ListRequestedServiceQuotaChangeHistoryByQuota",
-            ],
-            resources: ["*"],
-          }, {
-            actions: [
-              "iam:SimulatePrincipalPolicy",
-            ],
-            resources: ["*"],
-          }, {
-            actions: ["iam:PassRole"],
-            resources: ["arn:aws:iam::*:role/remotion-lambda-role"],
-          }, {
-            actions: [
-              "s3:GetObject",
-              "s3:DeleteObject",
-              "s3:PutObjectAcl",
-              "s3:PutObject",
-              "s3:CreateBucket",
-              "s3:ListBucket",
-              "s3:GetBucketLocation",
-              "s3:PutBucketAcl",
-              "s3:DeleteBucket",
-              "s3:PutBucketOwnershipControls",
-              "s3:PutBucketPublicAccessBlock",
-              "s3:PutLifecycleConfiguration",
-            ],
-            resources: ["arn:aws:s3:::remotionlambda-*"],
-          }, {
-            actions: ["s3:ListAllMyBuckets"],
-            resources: ["*"],
-          }, {
-            actions: ["lambda:ListFunctions", "lambda:GetFunction"],
-            resources: ["*"],
-          }, {
-            actions: [
-              "lambda:InvokeAsync",
-              "lambda:InvokeFunction",
-              "lambda:CreateFunction",
-              "lambda:DeleteFunction",
-              "lambda:PutFunctionEventInvokeConfig",
-              "lambda:PutRuntimeManagementConfig",
-              "lambda:TagResource",
-            ],
-            resources: ["arn:aws:lambda:*:*:function:remotion-render-*"],
-          }, {
-            actions: [
-              "logs:CreateLogGroup",
-              "logs:PutRetentionPolicy",
-            ],
-            resources: [
-              "arn:aws:logs:*:*:log-group:/aws/lambda/remotion-render-*",
-            ],
-          }, {
-            actions: ["lambda:GetLayerVersion"],
-            resources: [
-              "arn:aws:lambda:*:678892195805:layer:remotion-binaries-*",
-              "arn:aws:lambda:*:580247275435:layer:LambdaInsightsExtension*",
-            ],
-          }]);
-        },
       },
     });
   },


### PR DESCRIPTION
## **User description**
Updates the nextjs permissions to use the "remotion-executionrole-policy`: https://www.remotion.dev/docs/lambda/without-iam/#1-create-role-policy. This means we don't need to pass in AWS admin keys anymore.


___

## **Type**
enhancement


___

## **Description**
- Imported `pulumi` to manage AWS resources more efficiently.
- Enhanced security by removing the need for AWS admin keys in environment variables.
- Implemented a new permissions model using the remotion execution role policy, as recommended in the Remotion documentation.
- Defined granular permissions for AWS services like Service Quotas, IAM, S3, Lambda, and Logs to ensure least privilege access.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sst.config.ts</strong><dd><code>Enhance Security by Using Remotion Execution Role Policy and Removing </code><br><code>AWS Admin Keys</code></dd></summary>
<hr>
      
sst.config.ts

<li>Imported <code>pulumi</code> from <code>@pulumi/pulumi</code>.<br> <li> Removed AWS admin keys from environment variables.<br> <li> Added a transformation function to combine linked permissions with the <br>remotion execution role policy.<br> <li> Defined specific actions and resources for various AWS services <br>including Service Quotas, IAM, S3, Lambda, and Logs.<br>


</details>
    

  </td>
  <td><a href="https://github.com/karelnagel/pulumi-remotion-lambda/pull/2/files#diff-6ae5efcb80db51f4b137515e1674caaf950405317e84e2961cf38f9d3a1804b9">+76/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

