### PR TITLE
Using SST resource linking to link remotion to client

### DIFF
--- a/client/src/pages/api/render.ts
+++ b/client/src/pages/api/render.ts
@@ -1,28 +1,24 @@
 import type { APIRoute } from "astro";
 import { renderMediaOnLambda, getRenderProgress } from "@remotion/lambda/client";
+import { Resource } from "sst";
 
 export const POST: APIRoute = async () => {
-  const functionName = import.meta.env.REMOTION_FUNCTION_NAME;
-  const bucketName = import.meta.env.REMOTION_BUCKET_NAME;
-  const serveUrl = import.meta.env.REMOTION_SITE_URL;
-
-  console.log({ functionName, serveUrl, bucketName });
   const res = await renderMediaOnLambda({
-    functionName,
-    serveUrl,
+    functionName: Resource.Remotion.functionName,
+    serveUrl: Resource.Remotion.siteUrl,
     composition: "HelloWorld",
     codec: "h264",
     privacy: "no-acl",
     region: "eu-central-1",
-    forceBucketName: bucketName,
+    forceBucketName: Resource.Remotion.bucketName,
   });
 
   while (true) {
     await new Promise((resolve) => setTimeout(resolve, 2000));
     const progress = await getRenderProgress({
       renderId: res.renderId,
-      bucketName,
-      functionName,
+      bucketName: Resource.Remotion.bucketName,
+      functionName: Resource.Remotion.functionName,
       region: "eu-central-1",
     });
 

--- a/client/src/pages/index.astro
+++ b/client/src/pages/index.astro
@@ -1,4 +1,5 @@
 ---
+import { Resource } from "sst";
 
 ---
 
@@ -13,9 +14,9 @@
 	<body>
 		<h1>Astro</h1>
 		<div>
-			<p>site: {import.meta.env.REMOTION_SITE_URL}</p>
-			<p>function: {import.meta.env.REMOTION_FUNCTION_NAME}</p>
-			<button >render</button>
+			<p>site: {Resource.Remotion.siteUrl}</p>
+			<p>function: {Resource.Remotion.functionName}</p>
+			<button>render</button>
 			<video controls id="video"></video>
 			<div id="result"></div>
 		</div>

--- a/client/sst-env.d.ts
+++ b/client/sst-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.sst/types.generated.ts" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pulumi-remotion-lambda",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pulumi-remotion-lambda",
-      "version": "0.0.1",
+      "version": "0.0.5",
       "workspaces": [
         "remotion-example",
         "client"
@@ -15,7 +15,8 @@
         "@pulumi/aws": "^6.27.0",
         "@pulumi/pulumi": "^3.111.1",
         "@remotion/lambda": "4.0.130",
-        "remotion": "4.0.130"
+        "remotion": "4.0.130",
+        "sst": "^3.0.13"
       }
     },
     "client": {
@@ -813,6 +814,34 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.477.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.477.0.tgz",
+      "integrity": "sha512-o0434EH+d1BxHZvgG7z8vph2SYefciQ5RnJw2MgvETGnthgqsnI4nnNJLSw0FVeqCeS18n6vRtzqlGYR2YPCNg==",
+      "dependencies": {
+        "@smithy/core": "^1.2.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@aws-sdk/credential-provider-cognito-identity": {
       "version": "3.382.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.382.0.tgz",
@@ -1144,6 +1173,21 @@
         "@aws-sdk/util-endpoints": "3.382.0",
         "@smithy/protocol-http": "^2.0.1",
         "@smithy/types": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.470.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.470.0.tgz",
+      "integrity": "sha512-C1o1J06iIw8cyAAOvHqT4Bbqf+PgQ/RDlSyjt2gFfP2OovDpc2o2S90dE8f8iZdSGpg70N5MikT1DBhW9NbhtQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-config-provider": "^2.0.0",
+        "@smithy/util-middleware": "^2.0.8",
         "tslib": "^2.5.0"
       },
       "engines": {
@@ -3587,6 +3631,36 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@smithy/core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.4.2.tgz",
+      "integrity": "sha512-2fek3I0KZHWJlRLvRTqxTEri+qV0GRHrJIoLFuBMZB4EMg4WgeBGfF0X6abnrNYpq55KJ6R4D6x4f0vLnhzinA==",
+      "dependencies": {
+        "@smithy/middleware-endpoint": "^2.5.1",
+        "@smithy/middleware-retry": "^2.3.1",
+        "@smithy/middleware-serde": "^2.3.0",
+        "@smithy/protocol-http": "^3.3.0",
+        "@smithy/smithy-client": "^2.5.1",
+        "@smithy/types": "^2.12.0",
+        "@smithy/util-middleware": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.3.0.tgz",
@@ -3782,9 +3856,9 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.0.tgz",
-      "integrity": "sha512-OBhI9ZEAG8Xen0xsFJwwNOt44WE2CWkfYIxTognC8x42Lfsdf0VN/wCMqpdkySMDio/vts10BiovAxQp0T0faA==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.5.1.tgz",
+      "integrity": "sha512-1/8kFp6Fl4OsSIVTWHnNjLnTL8IqpIb/D3sTSczrKFnrE9VMNWxnrRKNvpUHOJ6zpGD5f62TPm7+17ilTJpiCQ==",
       "dependencies": {
         "@smithy/middleware-serde": "^2.3.0",
         "@smithy/node-config-provider": "^2.3.0",
@@ -3799,19 +3873,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.2.0.tgz",
-      "integrity": "sha512-PsjDOLpbevgn37yJbawmfVoanru40qVA8UEf2+YA1lvOefmhuhL6ZbKtGsLAWDRnE1OlAmedsbA/htH6iSZjNA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.3.1.tgz",
+      "integrity": "sha512-P2bGufFpFdYcWvqpyqqmalRtwFUNUA8vHjJR5iGqbfR6mp65qKOLcUd6lTr4S9Gn/enynSrSf3p3FVgVAf6bXA==",
       "dependencies": {
         "@smithy/node-config-provider": "^2.3.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/service-error-classification": "^2.1.5",
-        "@smithy/smithy-client": "^2.5.0",
+        "@smithy/smithy-client": "^2.5.1",
         "@smithy/types": "^2.12.0",
         "@smithy/util-middleware": "^2.2.0",
         "@smithy/util-retry": "^2.2.0",
         "tslib": "^2.6.2",
-        "uuid": "^8.3.2"
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3997,11 +4071,11 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.0.tgz",
-      "integrity": "sha512-DDXWHWdimtS3y/Kw1Jo46KQ0ZYsDKcldFynQERUGBPDpkW1lXOTHy491ALHjwfiBQvzsVKVxl5+ocXNIgJuX4g==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.5.1.tgz",
+      "integrity": "sha512-jrbSQrYCho0yDaaf92qWgd+7nAeap5LtHTI51KXqmpIFCceKU3K9+vIVTUH72bOJngBMqa4kyu1VJhRcSrk/CQ==",
       "dependencies": {
-        "@smithy/middleware-endpoint": "^2.5.0",
+        "@smithy/middleware-endpoint": "^2.5.1",
         "@smithy/middleware-stack": "^2.2.0",
         "@smithy/protocol-http": "^3.3.0",
         "@smithy/types": "^2.12.0",
@@ -4130,6 +4204,19 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.2.0.tgz",
+      "integrity": "sha512-BuDHv8zRjsE5zXd3PxFXFknzBG3owCpjq8G3FcsXW3CykYXuEqM3nTSsmLzw5q+T12ZYuDlVUZKBdpNbhVtlrQ==",
+      "dependencies": {
+        "@smithy/node-config-provider": "^2.3.0",
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
@@ -9061,6 +9148,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hono": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.0.1.tgz",
+      "integrity": "sha512-S9cREGPJIAK437RhroOf1PGlJPIlt5itl69OmQ6onPLo5pdCbSHGL8v4uAKxrdHjcTyuoyvKPqWm5jv0dGkdFA==",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
@@ -9742,6 +9837,14 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.2.3.tgz",
+      "integrity": "sha512-KUXdbctm1uHVL8BYhnyHkgp3zDX5KW8ZhAKVFEfUbU2P8Alpzjb+48hHvjOdQIyPshoblhzsuqOwEEAbtHVirA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -11386,6 +11489,14 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
@@ -11484,6 +11595,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
+      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -11520,6 +11639,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.6.4.tgz",
+      "integrity": "sha512-T1h3B10BRPKfcObdBklX639tVz+xh34O7GjofqrqiAQdm7eHsQ00ih18x6wuJ/E6FxdtS2u3FmUGPDeEcMwzNA==",
+      "dependencies": {
+        "jose": "^4.15.4",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.5.tgz",
+      "integrity": "sha512-jc7BFxgKPKi94uOvEmzlSWFFe2+vASyXaKUpdQKatWAESU2MWjDfFf0fdfc83CDKcA5QecabZeNLyfhe3yKNkg==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/optionator": {
@@ -13648,6 +13800,460 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/sst": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/sst/-/sst-3.0.13.tgz",
+      "integrity": "sha512-IJO3ZHJ3/4gEEGyhvs9dwryC5il044NxYh0meD2pOKwBgdMREIONnrx+F8Tkblf88RB0zP7u7gllxlzxvYQuWA==",
+      "dependencies": {
+        "@aws-sdk/client-lambda": "3.478.0",
+        "hono": "4.0.1",
+        "jose": "5.2.3",
+        "openid-client": "5.6.4"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/client-lambda": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.478.0.tgz",
+      "integrity": "sha512-7+PEE1aV3qVeuswL6cUBfHeljxC/WaXFj+214/W3q71uRdLbX5Z7ZOD15sJbjSu+4VZN9ugMaxEcp+oLiqWl+A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.478.0",
+        "@aws-sdk/core": "3.477.0",
+        "@aws-sdk/credential-provider-node": "3.478.0",
+        "@aws-sdk/middleware-host-header": "3.468.0",
+        "@aws-sdk/middleware-logger": "3.468.0",
+        "@aws-sdk/middleware-recursion-detection": "3.468.0",
+        "@aws-sdk/middleware-signing": "3.468.0",
+        "@aws-sdk/middleware-user-agent": "3.478.0",
+        "@aws-sdk/region-config-resolver": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.478.0",
+        "@aws-sdk/util-user-agent-browser": "3.468.0",
+        "@aws-sdk/util-user-agent-node": "3.470.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/core": "^1.2.0",
+        "@smithy/eventstream-serde-browser": "^2.0.15",
+        "@smithy/eventstream-serde-config-resolver": "^2.0.15",
+        "@smithy/eventstream-serde-node": "^2.0.15",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/hash-node": "^2.0.17",
+        "@smithy/invalid-dependency": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/middleware-retry": "^2.0.24",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.22",
+        "@smithy/util-defaults-mode-node": "^2.0.29",
+        "@smithy/util-endpoints": "^1.0.7",
+        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-stream": "^2.0.23",
+        "@smithy/util-utf8": "^2.0.2",
+        "@smithy/util-waiter": "^2.0.15",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/client-sso": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.478.0.tgz",
+      "integrity": "sha512-Jxy9cE1JMkPR0PklCpq3cORHnZq/Z4klhSTNGgZNeBWovMa+plor52kyh8iUNHKl3XEJvTbHM7V+dvrr/x0P1g==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.477.0",
+        "@aws-sdk/middleware-host-header": "3.468.0",
+        "@aws-sdk/middleware-logger": "3.468.0",
+        "@aws-sdk/middleware-recursion-detection": "3.468.0",
+        "@aws-sdk/middleware-user-agent": "3.478.0",
+        "@aws-sdk/region-config-resolver": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.478.0",
+        "@aws-sdk/util-user-agent-browser": "3.468.0",
+        "@aws-sdk/util-user-agent-node": "3.470.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/core": "^1.2.0",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/hash-node": "^2.0.17",
+        "@smithy/invalid-dependency": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/middleware-retry": "^2.0.24",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.22",
+        "@smithy/util-defaults-mode-node": "^2.0.29",
+        "@smithy/util-endpoints": "^1.0.7",
+        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/client-sts": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.478.0.tgz",
+      "integrity": "sha512-D+QID0dYzmn9dcxgKP3/nMndUqiQbDLsqI0Zf2pG4MW5gPhVNKlDGIV3Ztz8SkMjzGJExNOLW2L569o8jshJVw==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/core": "3.477.0",
+        "@aws-sdk/credential-provider-node": "3.478.0",
+        "@aws-sdk/middleware-host-header": "3.468.0",
+        "@aws-sdk/middleware-logger": "3.468.0",
+        "@aws-sdk/middleware-recursion-detection": "3.468.0",
+        "@aws-sdk/middleware-user-agent": "3.478.0",
+        "@aws-sdk/region-config-resolver": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.478.0",
+        "@aws-sdk/util-user-agent-browser": "3.468.0",
+        "@aws-sdk/util-user-agent-node": "3.470.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/core": "^1.2.0",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/hash-node": "^2.0.17",
+        "@smithy/invalid-dependency": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/middleware-retry": "^2.0.24",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.22",
+        "@smithy/util-defaults-mode-node": "^2.0.29",
+        "@smithy/util-endpoints": "^1.0.7",
+        "@smithy/util-middleware": "^2.0.8",
+        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-utf8": "^2.0.2",
+        "fast-xml-parser": "4.2.5",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.468.0.tgz",
+      "integrity": "sha512-k/1WHd3KZn0EQYjadooj53FC0z24/e4dUZhbSKTULgmxyO62pwh9v3Brvw4WRa/8o2wTffU/jo54tf4vGuP/ZA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.478.0.tgz",
+      "integrity": "sha512-SsrYEYUvTG9ZoPC+zB19AnVoOKID+QIEHJDIi1GCZXW5kTVyr1saTVm4orG2TjYvbHQMddsWtHOvGYXZWAYMbw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.468.0",
+        "@aws-sdk/credential-provider-process": "3.468.0",
+        "@aws-sdk/credential-provider-sso": "3.478.0",
+        "@aws-sdk/credential-provider-web-identity": "3.468.0",
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.478.0.tgz",
+      "integrity": "sha512-nwDutJYeHiIZCQDgKIUrsgwAWTil0mNe+cbd+j8fi+wwxkWUzip+F0+z02molJ8WrUUKNRhqB1V5aVx7IranuA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.468.0",
+        "@aws-sdk/credential-provider-ini": "3.478.0",
+        "@aws-sdk/credential-provider-process": "3.468.0",
+        "@aws-sdk/credential-provider-sso": "3.478.0",
+        "@aws-sdk/credential-provider-web-identity": "3.468.0",
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/credential-provider-imds": "^2.0.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.468.0.tgz",
+      "integrity": "sha512-OYSn1A/UsyPJ7Z8Q2cNhTf55O36shPmSsvOfND04nSfu1nPaR+VUvvsP7v+brhGpwC/GAKTIdGAo4blH31BS6A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.478.0.tgz",
+      "integrity": "sha512-LsDShG51X/q+s5ZFN7kHVqrd8ZHdyEyHqdhoocmRvvw2Dif50M0AqQfvCrW1ndj5CNzXO4x/eH8EK5ZOVlS6Sg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.478.0",
+        "@aws-sdk/token-providers": "3.478.0",
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.468.0.tgz",
+      "integrity": "sha512-rexymPmXjtkwCPfhnUq3EjO1rSkf39R4Jz9CqiM7OsqK2qlT5Y/V3gnMKn0ZMXsYaQOMfM3cT5xly5R+OKDHlw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.468.0.tgz",
+      "integrity": "sha512-gwQ+/QhX+lhof304r6zbZ/V5l5cjhGRxLL3CjH1uJPMcOAbw9wUlMdl+ibr8UwBZ5elfKFGiB1cdW/0uMchw0w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.468.0.tgz",
+      "integrity": "sha512-X5XHKV7DHRXI3f29SAhJPe/OxWRFgDWDMMCALfzhmJfCi6Jfh0M14cJKoC+nl+dk9lB+36+jKjhjETZaL2bPlA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.468.0.tgz",
+      "integrity": "sha512-vch9IQib2Ng9ucSyRW2eKNQXHUPb5jUPCLA5otTW/8nGjcOU37LxQG4WrxO7uaJ9Oe8hjHO+hViE3P0KISUhtA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.468.0.tgz",
+      "integrity": "sha512-s+7fSB1gdnnTj5O0aCCarX3z5Vppop8kazbNSZADdkfHIDWCN80IH4ZNjY3OWqaAz0HmR4LNNrovdR304ojb4Q==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/signature-v4": "^2.0.0",
+        "@smithy/types": "^2.7.0",
+        "@smithy/util-middleware": "^2.0.8",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.478.0.tgz",
+      "integrity": "sha512-Rec+nAPIzzwxgHPW+xqY6tooJGFOytpYg/xSRv8/IXl3xKGhmpMGs6gDWzmMBv/qy5nKTvLph/csNWJ98GWXCw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.478.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/token-providers": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.478.0.tgz",
+      "integrity": "sha512-7b5tj1y/wGHZIZ+ckjOUKgKrMuCJMF/G1UKZKIqqdekeEsjcThbvoxAMeY0FEowu2ODVk/ggOmpBFxcu0iYd6A==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/middleware-host-header": "3.468.0",
+        "@aws-sdk/middleware-logger": "3.468.0",
+        "@aws-sdk/middleware-recursion-detection": "3.468.0",
+        "@aws-sdk/middleware-user-agent": "3.478.0",
+        "@aws-sdk/region-config-resolver": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-endpoints": "3.478.0",
+        "@aws-sdk/util-user-agent-browser": "3.468.0",
+        "@aws-sdk/util-user-agent-node": "3.470.0",
+        "@smithy/config-resolver": "^2.0.21",
+        "@smithy/fetch-http-handler": "^2.3.1",
+        "@smithy/hash-node": "^2.0.17",
+        "@smithy/invalid-dependency": "^2.0.15",
+        "@smithy/middleware-content-length": "^2.0.17",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/middleware-retry": "^2.0.24",
+        "@smithy/middleware-serde": "^2.0.15",
+        "@smithy/middleware-stack": "^2.0.9",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/node-http-handler": "^2.2.1",
+        "@smithy/property-provider": "^2.0.0",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/shared-ini-file-loader": "^2.0.6",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "@smithy/url-parser": "^2.0.15",
+        "@smithy/util-base64": "^2.0.1",
+        "@smithy/util-body-length-browser": "^2.0.1",
+        "@smithy/util-body-length-node": "^2.1.0",
+        "@smithy/util-defaults-mode-browser": "^2.0.22",
+        "@smithy/util-defaults-mode-node": "^2.0.29",
+        "@smithy/util-endpoints": "^1.0.7",
+        "@smithy/util-retry": "^2.0.8",
+        "@smithy/util-utf8": "^2.0.2",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/types": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.468.0.tgz",
+      "integrity": "sha512-rx/9uHI4inRbp2tw3Y4Ih4PNZkVj32h7WneSg3MVgVjAoVD5Zti9KhS5hkvsBxfgmQmg0AQbE+b1sy5WGAgntA==",
+      "dependencies": {
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.478.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.478.0.tgz",
+      "integrity": "sha512-u9Mcg3euGJGs5clPt9mBuhBjHiEKiD0PnfvArhfq9i+dcY5mbCq/i1Dezp3iv1fZH9xxQt7hPXDfSpt1yUSM6g==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/util-endpoints": "^1.0.7",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.468.0.tgz",
+      "integrity": "sha512-OJyhWWsDEizR3L+dCgMXSUmaCywkiZ7HSbnQytbeKGwokIhD69HTiJcibF/sgcM5gk4k3Mq3puUhGnEZ46GIig==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/types": "^2.7.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/sst/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.470.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.470.0.tgz",
+      "integrity": "sha512-QxsZ9iVHcBB/XRdYvwfM5AMvNp58HfqkIrH88mY0cmxuvtlIGDfWjczdDrZMJk9y0vIq+cuoCHsGXHu7PyiEAQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/node-config-provider": "^2.1.8",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/sst/node_modules/@smithy/protocol-http": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.3.0.tgz",
+      "integrity": "sha512-Xy5XK1AFWW2nlY/biWZXu6/krgbaf2dg0q492D8M5qthsnU2H+UgFeZLbM76FnH7s6RO/xhQRkj+T6KBO3JzgQ==",
+      "dependencies": {
+        "@smithy/types": "^2.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
@@ -14610,9 +15216,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@pulumi/aws": "^6.27.0",
     "@pulumi/pulumi": "^3.111.1",
     "@remotion/lambda": "4.0.130",
-    "remotion": "4.0.130"
+    "remotion": "4.0.130",
+    "sst": "^3.0.13"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -7,24 +7,14 @@ Easy to deploy Remotion Lambda with Pulumi/SST in a few lines of code and after 
 ```ts
 const remotion = new RemotionLambda("Remotion", {
     path: "remotion-example",
-    function: {
-        ephemerealStorageInMb: 2048,
-        memorySizeInMb: 2048,
-        timeoutInSeconds: 120,
-    },
 });
 new sst.aws.Astro("Client", {
     path: "client",
-    environment: {
-    REMOTION_FUNCTION_NAME: remotion.function.name,
-    REMOTION_SITE_URL: remotion.siteUrl,
-    REMOTION_BUCKET_NAME: remotion.bucket.bucket,
-    },
+    link: [remotion]
 });
 ```
 
 ## Todo
-- make it possible to deploy multiple stacks (main, dev, etc) in the same account, currently setting the function, role and bucket name are hardcoded so you can't have the same name with different stacks
 - custom domains for lambda, like SST does for every FE stack
 - everything in bucket is public
 - the first deploy fails rn bc bucket isn't ready yet, so you need to run deploy twice at first

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ import { hostedLayers } from "./hosted-layers";
 import fs from "fs";
 import { execSync } from "child_process";
 import path from "path";
-// Todo: probably not the best place to import this
-import { Link } from "../.sst/platform/src/components";
 
 type RemotionLambdaConfig = {
   path: string;
@@ -16,7 +14,7 @@ type RemotionLambdaConfig = {
   memorySizeInMb?: number;
 };
 
-export class RemotionLambda extends pulumi.ComponentResource implements Link.Linkable, Link.AWS.Linkable {
+export class RemotionLambda extends pulumi.ComponentResource {
   public bucket: aws.s3.Bucket;
   public function: aws.lambda.Function;
   public siteUrl: pulumi.Output<string>;
@@ -248,7 +246,7 @@ export class RemotionLambda extends pulumi.ComponentResource implements Link.Lin
 
     this.registerOutputs({});
   }
-  getSSTLink(): Link.Definition {
+  getSSTLink() {
     return {
       properties: {
         functionName: this.function.name,
@@ -258,7 +256,7 @@ export class RemotionLambda extends pulumi.ComponentResource implements Link.Lin
     };
   }
 
-  getSSTAWSPermissions(): sst.aws.FunctionPermissionArgs[] {
+  getSSTAWSPermissions() {
     return this.permissions;
   }
 }

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -6,7 +6,7 @@ export default $config({
   app: (input) => {
     return {
       name: "pulumi-remotion",
-      removal: input?.stage === "production" ? "retain" : "remove",
+      removal: "remove",
       home: "aws",
       providers: {
         aws: { region: "eu-central-1" },

--- a/sst.config.ts
+++ b/sst.config.ts
@@ -17,20 +17,10 @@ export default $config({
     const remotion = new RemotionLambda("Remotion", {
       path: "remotion-example",
       forceDestroy: true,
-      function: {
-        ephemerealStorageInMb: 2048,
-        memorySizeInMb: 2048,
-        timeoutInSeconds: 120,
-      },
     });
     new sst.aws.Astro("Client", {
       path: "client",
-      permissions: remotion.permissions,
-      environment: {
-        REMOTION_FUNCTION_NAME: remotion.function.name,
-        REMOTION_SITE_URL: remotion.siteUrl,
-        REMOTION_BUCKET_NAME: remotion.bucket.bucket,
-      },
+      link: [remotion],
     });
   },
 });


### PR DESCRIPTION
This way there is no need to attach permissions, function names, sites and buckets separately. This works in this repo rn, but since the Link module is imported from "../.sst/platform/src/components", it won't work as a library.

Makes it even easier to define the stack:
```ts
const remotion = new RemotionLambda("Remotion", {
    path: "remotion-example",
});
new sst.aws.Astro("Client", {
    path: "client",
    link: [remotion]
});
```
and later use (should also be typesafe):
```ts
import { Resource } from "sst"

Resource.Remotion.functionName
```